### PR TITLE
19: Add github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: Report a bug
+description: Errors and regression reports with complete reproducing test cases.
+body:
+  - type: markdown
+    attributes:
+      value: "
+
+**GUIDELINES FOR REPORTING BUGS**
+
+1. a **succinct description of the problem** - typically a line or two at most
+
+2. succinct, dependency-free code which reproduces the problem, otherwise known as an MCVE.
+
+3. complete stack traces for all errors - please avoid screenshots, use formatted text inside issues
+
+4. Other things as applicable.
+"
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+
+  - type: input
+    id: python_version
+    attributes:
+      label: Python Version
+      description: Assumes cpython unless otherwise stated, e.g. 3.10, 3.11, pypy.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: To Reproduce
+      description: "
+Provide your [Minimal, Complete, and Verifiable](https://stackoverflow.com/help/mcve) example here.
+"
+      placeholder: "# Insert code here (text area already python formatted)"
+      render: python
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Error
+      description: "
+Provide the complete text of any errors/warnings received **including the complete stack trace, if applicable**.
+"
+      placeholder: "# Copy the complete stack trace and error message here"
+      value: "\
+```
+
+# Copy the complete stack trace and error message here.
+
+```
+"
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: "**Have a nice day!**"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/use_case.yml
+++ b/.github/ISSUE_TEMPLATE/use_case.yml
@@ -1,0 +1,27 @@
+name: Discribe a new use case
+description: Request new functionality / extension of existing functionality
+body:
+  - type: textarea
+    attributes:
+      label: Describe the use case
+      description: A clear and concise description of what the use case is.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Example Use
+      description: How is it going to be used? Ideally provide a code snippet.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context about the use case here.
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: "**Have a nice day!**"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+<!-- Provide an issue id and a brief summary of your changes in the title above -->
+
+## Description
+<!-- Describe your changes in more detail -->
+<!-- Remember to link your PR to the issue it resolves, consider creating one if it doesn't exist -->


### PR DESCRIPTION
Resolve #19: add templates for issue forms and a basic PR template.

Currently bug report and feature request issues are covered.
Feature request has been converted into a "use case" like [sqlalchemy](https://github.com/sqlalchemy/sqlalchemy/blob/main/.github/ISSUE_TEMPLATE/use_case.yaml) does it - this feels much more informative, as it requires to describe a usage scenario as opposed to an implementation.