### PR TITLE
21: Add contributing docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,7 +16,7 @@ poetry install
 poetry shell
 ```
 
-Poetry keeps virtualenvs in `$HOME/.cache/pypoetry/virtualenvs` by default. If you use VSCode, you'll need to point it at this path for it to recognize the virtualenv: add `"python.venvPath": "$HOME/.cache/pypoetry/virtualenvs"` to your settings. Alternatively, you can make it create virtualenvs in a classic per-project `.venv` directory:
+Poetry keeps virtualenvs in `$HOME/.cache/pypoetry/virtualenvs` by default. If you use VSCode, you'll need to point it at this path for it to recognize the virtualenv: add `"python.venvPath": "$HOME/.cache/pypoetry/virtualenvs"` to your settings. Alternatively, you can make poetry create virtualenvs in a classic per-project `.venv` directory:
 ```bash
 poetry config virtualenvs.in-project true
 ```


### PR DESCRIPTION
Closes #21: Add a `CONTRIBUTING.md` file and move all development setup instructions there.

Key changes:
- Move to `make` commands for most of the setup instructions
- Remove outdated instructions
- Add mention of `pre-commit` install
